### PR TITLE
[DIGI-20893] Prevent 404 when headers are sent

### DIFF
--- a/lib/restify_middleware.js
+++ b/lib/restify_middleware.js
@@ -24,7 +24,7 @@ function Middleware(runner) {
         req.query = undefined; // oddly, req.query is a function in Restify, kill it
         chain(req, res, function(err) {
           if (err) { return next(err); }
-          if (!res.finished) {
+          if (!res.finished && !res.headersSent) {
             res.statusCode = 404;
             res.end('Not found');
           }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-node-runner",
-  "version": "0.8.2-patch.2",
+  "version": "0.8.2-patch.3",
   "description": "Swagger loader and middleware utilities",
   "keywords": [
     "swagger",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "swagger-node-runner",
-  "version": "0.8.2-patch.3",
+  "version": "0.8.2-patch.4",
   "description": "Swagger loader and middleware utilities",
   "keywords": [
     "swagger",


### PR DESCRIPTION
 - Prevent default `404 Not Found` handling in `restify_middleware.js`
 - Applicable when response is being compressed with `Transfer-Encoding: chunked` e.g. for gzip